### PR TITLE
Respect verbosity

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
+    - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install --global npm@latest

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = opts => {
 
 	opts = opts || {};
 
-	const args = ['/v', '/nh', '/fo', 'csv'];
+	const args = ['/nh', '/fo', 'csv'];
+
+	if (opts.verbose) {
+		args.push('/v');
+	}
 
 	if (opts.system && opts.username && opts.password) {
 		args.push(


### PR DESCRIPTION
This fixes #16. (At least) on my machine, adding the verbose flag (`/V`) made `tasklist` slow down dramatically. This patch only adds the /v option if the verbose opt is set, and fixes `tasklist` (again, at least on my machine).

With the PR:
```
$ time node -e 'require(".")().then(arr => console .log("found " + arr.length + " procs"))'
found 231 procs

real    0m0.717s
user    0m0.000s
sys     0m0.031s
```

Without this PR, off of master:

```
$ time node -e 'require(".")().then(arr => console.log("found  " + arr.length + " procs"))'
found 231 procs

real    0m5.558s
user    0m0.015s
sys     0m0.015s
```