### PR TITLE
force stdout to use UTF-8 encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = (options = {}) => {
 
 	if (Array.isArray(options.filter)) {
 		for (const filter of options.filter) {
-			args.push('/fi', filter);
+			args.push('/fi', JSON.stringify(filter));
 		}
 	}
 
@@ -45,8 +45,10 @@ module.exports = (options = {}) => {
 	]);
 
 	const headers = options.verbose ? verboseHeaders : defaultHeaders;
+	const command = '@chcp 65001 >nul & tasklist ' + args.join(' ');
+	console.log('ARGS', args);
 
-	return pify(childProcess.execFile)('tasklist', args)
+	return pify(childProcess.exec)(command)
 		// `INFO:` means no matching tasks. See #9.
 		.then(stdout => stdout.startsWith('INFO:') ? [] : neatCsv(stdout, {headers}))
 		.then(data => data.map(task => {


### PR DESCRIPTION
Ensure tasklist output is in UTF-8 format, otherwise tasks with windowTitles containing UTF-8 chars will be rendered as � instead.

E.g. A task with windowTitle
"how to open new window · Issue #401 · SimulatedGREG/electron-vue - Google Chrome" 
would register as 
"how to open new window � Issue #401 � SimulatedGREG/electron-vue - Google Chrome" 
in the tasklist output instead, if stdout wasn't specified to use the UTF-8 charset